### PR TITLE
Address the concurrency issues in the KademliaNode

### DIFF
--- a/src/routing_table.rs
+++ b/src/routing_table.rs
@@ -5,6 +5,7 @@ use std::net::SocketAddr;
 use std::collections::BinaryHeap;
 use std::fmt;
 use std::backtrace::Backtrace;
+use parking_lot::RwLock;
 
 
 /// Struct representing the routing table of a Kademlia DHT node.


### PR DESCRIPTION
KademliaNode is now wrapped in an Arc, allowing it to be safely shared across threads. RoutingTable now uses RwLock for each bucket, allowing concurrent reads and exclusive writes. 
StorageManager uses a thread-safe DashMap and an Arc-wrapped cache. 
All methods that modify shared state now take &Arc<Self> instead of &mut self, ensuring thread-safety.
 The run method now takes Arc<Self>, allowing it to be run in a separate task.